### PR TITLE
Prefer prefix ++/-- operators for non-primitive types

### DIFF
--- a/src/onig-scanner.cc
+++ b/src/onig-scanner.cc
@@ -97,7 +97,7 @@ Handle<Value> OnigScanner::FindNextMatch(Handle<String> v8String, Handle<Number>
       }
     }
 
-    iter++;
+    ++iter;
     index++;
   }
 


### PR DESCRIPTION
Pre-increment/decrement can be more efficient than post-increment/decrement. Post-increment/decrement usually involves keeping a copy of the previous value around and adds a little extra code.

Issue(s) found via [cppcheck](http://cppcheck.sourceforge.net/).
