### PR TITLE
Update onig-searcher.cc

### DIFF
--- a/src/onig-searcher.cc
+++ b/src/onig-searcher.cc
@@ -30,7 +30,7 @@ shared_ptr<OnigResult> OnigSearcher::Search(const string& stringToSearch, wchar_
         bestResult = result;
       }
 
-      if (location == charOffset) {
+      if (location == byteOffset) {
         break;
       }
     }


### PR DESCRIPTION
I was just browsing the code when I noticed something that I thought was odd: the `if (location == charOffset)` condition is comparing two different units of measure - bytes and characters, respectively. I could be wrong, but I think `charOffset` should be replaced with `byteOffset` in that condition.

Thoughts?
