### PR TITLE
add freebsd compiler flags

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -133,6 +133,11 @@
             'src/unicode-utils-posix.cc'
           ],
         }],
+        ['OS=="freebsd"', {
+          'cflags': [
+            '-std=c++0x',
+          ]
+        }]
       ]
     }
   ]


### PR DESCRIPTION
This addresses https://github.com/atom/node-oniguruma/issues/10 .
Tested on every compiler on FreeBSD 10.1 (x64):
- gcc-4.6
- gcc-4.7
- gcc-4.8
- gcc-4.9
- gcc-5
- clang-3.4.1 (which is the default compiler)

Still needs setting CC and CXX variables.
