### PR TITLE
Fixed bug #35: memory leak in OnigStringContext

### DIFF
--- a/src/onig-string-context.cc
+++ b/src/onig-string-context.cc
@@ -4,11 +4,7 @@
 OnigStringContext::OnigStringContext(Handle<String> str)
 // The v8::Persistent API changed recently and now it requires v8::Isolate
 // to the constructor argument.
-#if (0 == NODE_MAJOR_VERSION && 11 <= NODE_MINOR_VERSION) || (1 <= NODE_MAJOR_VERSION)
-  : v8String(Isolate::GetCurrent(), str),
-#else
-  : v8String(Persistent<String>::New(str)),
-#endif
+  : v8String(Nan::Global<String>(str)),
     utf8Value(str),
 #ifdef _WIN32
     utf16Value(str),
@@ -18,8 +14,4 @@ OnigStringContext::OnigStringContext(Handle<String> str)
 
 bool OnigStringContext::IsSame(Handle<String> other) const {
   return v8String == other;
-}
-
-OnigStringContext::~OnigStringContext() {
-    v8String.Reset();
 }

--- a/src/onig-string-context.cc
+++ b/src/onig-string-context.cc
@@ -19,3 +19,7 @@ OnigStringContext::OnigStringContext(Handle<String> str)
 bool OnigStringContext::IsSame(Handle<String> other) const {
   return v8String == other;
 }
+
+OnigStringContext::~OnigStringContext() {
+    v8String.Reset();
+}

--- a/src/onig-string-context.h
+++ b/src/onig-string-context.h
@@ -19,7 +19,6 @@ class OnigStringContext {
   bool HasMultibyteCharacters() const;
   const char* utf8_value() const { return *utf8Value; }
   size_t utf8_length() const { return utf8Value.length(); }
-  ~OnigStringContext();
 
 #ifdef _WIN32
   const wchar_t* utf16_value() const { return reinterpret_cast<const wchar_t*>(*utf16Value); }
@@ -28,7 +27,7 @@ class OnigStringContext {
   bool has_multibyte_characters() const { return hasMultibyteCharacters; }
 
  private:
-  Persistent<String> v8String;
+  Nan::Global<String> v8String;
   String::Utf8Value utf8Value;
 #ifdef _WIN32
   String::Value utf16Value;

--- a/src/onig-string-context.h
+++ b/src/onig-string-context.h
@@ -19,6 +19,7 @@ class OnigStringContext {
   bool HasMultibyteCharacters() const;
   const char* utf8_value() const { return *utf8Value; }
   size_t utf8_length() const { return utf8Value.length(); }
+  ~OnigStringContext();
 
 #ifdef _WIN32
   const wchar_t* utf16_value() const { return reinterpret_cast<const wchar_t*>(*utf16Value); }


### PR DESCRIPTION
Added a destructor that resets the Persistent to free the memory used for it. The `leaks.js` repro script that @soldair provided shows the heapUsed staying where it's expected.