### PR TITLE
memory leak fix for 4.2.2 

### DIFF
--- a/src/onig-string-context.cc
+++ b/src/onig-string-context.cc
@@ -19,3 +19,7 @@ OnigStringContext::OnigStringContext(Handle<String> str)
 bool OnigStringContext::IsSame(Handle<String> other) const {
   return v8String == other;
 }
+
+OnigStringContext::~OnigStringContext() {
+    v8String.Reset();
+}

--- a/src/onig-string-context.cc
+++ b/src/onig-string-context.cc
@@ -21,5 +21,9 @@ bool OnigStringContext::IsSame(Handle<String> other) const {
 }
 
 OnigStringContext::~OnigStringContext() {
-    v8String.Reset();
+#if (0 == NODE_MAJOR_VERSION && 10 == NODE_MINOR_VERSION)
+  v8String.Dispose();
+#else
+  v8String.Reset();
+#endif
 }

--- a/src/onig-string-context.h
+++ b/src/onig-string-context.h
@@ -19,6 +19,7 @@ class OnigStringContext {
   bool HasMultibyteCharacters() const;
   const char* utf8_value() const { return *utf8Value; }
   size_t utf8_length() const { return utf8Value.length(); }
+  ~OnigStringContext();
 
 #ifdef _WIN32
   const wchar_t* utf16_value() const { return reinterpret_cast<const wchar_t*>(*utf16Value); }


### PR DESCRIPTION
this is a fix for the 4.2.2 series. Ideally this can go out in a 4.2.3 patch release. This will allow the leak to be fixed in first-mate and atom while we wait for  5.x to compile on older node versions.

It differs because the use of Nan::Global is an error in node 0.10 so i rolled back to using icky ifdefs to call either Dispose or Reset on the Persistent via the OnigStringContext destructor.

This maintains the existing compatibility table for the current 4.2.2 series.
Tested on node 0.10.40, 0.12.7, and iojs 2.5
This module fails to build on iojs 3.x and node 4.x just like the current 4.2.2 release.

this is fairly high priority for me because I'm using a fork of oniguruma, first-mate, highlights, and marky-markdown to render readmes in npm/newww where i have to suppprt node 0.10 for a bit longer.
