### PR TITLE
Account for paired characters when translating char offsets to bytes

### DIFF
--- a/spec/onig-reg-exp-spec.coffee
+++ b/spec/onig-reg-exp-spec.coffee
@@ -140,6 +140,10 @@ describe 'OnigRegExp', ->
         expect(match[0].start).toBe 3
         expect(match[0].match).toBe "'"
 
+        match = regex.searchSync("'\uD835\uDF97'", 3)
+        expect(match[0].start).toBe 3
+        expect(match[0].match).toBe "'"
+
   describe '::testSync(string)', ->
     it 'returns true if the string matches the pattern', ->
       expect(new OnigRegExp("a[b-d]c").testSync('aec')).toBe false

--- a/spec/onig-scanner-spec.coffee
+++ b/spec/onig-scanner-spec.coffee
@@ -20,6 +20,25 @@ describe "OnigScanner", ->
         match = scanner.findNextMatchSync('ab…cde21', 5)
         expect(match.index).toBe 1
 
+    describe "when the string searched contains surrogate pairs", ->
+      it "counts paired characters as 2 characters in both arguments and return values", ->
+        scanner = new OnigScanner(["Y", "X"])
+        match = scanner.findNextMatchSync('a💻bYX', 0)
+        expect(match.captureIndices).toEqual [{index: 0, start: 4, end: 5, length: 1}]
+
+        match = scanner.findNextMatchSync('a💻bYX', 1)
+        expect(match.captureIndices).toEqual [{index: 0, start: 4, end: 5, length: 1}]
+
+        match = scanner.findNextMatchSync('a💻bYX', 3)
+        expect(match.captureIndices).toEqual [{index: 0, start: 4, end: 5, length: 1}]
+
+        match = scanner.findNextMatchSync('a💻bYX', 4)
+        expect(match.captureIndices).toEqual [{index: 0, start: 4, end: 5, length: 1}]
+
+        match = scanner.findNextMatchSync('a💻bYX', 5)
+        expect(match.index).toBe 1
+        expect(match.captureIndices).toEqual [{index: 0, start: 5, end: 6, length: 1}]
+
     it "returns false when the input string isn't a string", ->
       scanner = new OnigScanner(["1"])
       expect(scanner.findNextMatchSync()).toBe null

--- a/src/unicode-utils-posix.cc
+++ b/src/unicode-utils-posix.cc
@@ -41,8 +41,11 @@ int UnicodeUtils::bytes_in_characters(const char* string, int characters) {
       break;
 
     bytes += characterLength;
-    if (--characters == 0)
-      break;
+    if (characterLength == 4)
+      characters -= 2;
+    else
+      characters--;
+    if (characters <= 0) break;
 
     length -= characterLength;
     string += characterLength;


### PR DESCRIPTION
This fixes issues where we would start searching at the wrong point in the string when paired characters such as emojis preceded the start index.

Refs atom/first-mate#63
Refs atom/atom#9153