### PR TITLE
Fix two issues in utf8 <-> utf16 offset & lengths conversions

### DIFF
--- a/spec/onig-scanner-spec.coffee
+++ b/spec/onig-scanner-spec.coffee
@@ -20,6 +20,10 @@ describe "OnigScanner", ->
         match = scanner.findNextMatchSync('ab…cde21', 5)
         expect(match.index).toBe 1
 
+        scanner = new OnigScanner(['\"'])
+        match = scanner.findNextMatchSync('{"…": 1}', 1)
+        expect(match.captureIndices).toEqual [{index: 0, start: 1, end: 2, length: 1}]
+
     describe "when the string searched contains surrogate pairs", ->
       it "counts paired characters as 2 characters in both arguments and return values", ->
         scanner = new OnigScanner(["Y", "X"])

--- a/spec/onig-scanner-spec.coffee
+++ b/spec/onig-scanner-spec.coffee
@@ -53,6 +53,12 @@ describe "OnigScanner", ->
       expect(scanner.findNextMatchSync('a1', false).index).toBe 0
       expect(scanner.findNextMatchSync('a1', 'food').index).toBe 0
 
+  describe "when the regular expression contains double byte characters", ->
+    it "returns the correct match length", ->
+      scanner = new OnigScanner(["Возврат"])
+      match = scanner.findNextMatchSync('Возврат long_var_name;', 0)
+      expect(match.captureIndices).toEqual [{index: 0, start: 0, end: 7, length: 7}]
+
   describe "::findNextMatch", ->
     matchCallback = null
 

--- a/src/onig-scanner-worker.cc
+++ b/src/onig-scanner-worker.cc
@@ -19,13 +19,13 @@ void OnigScannerWorker::HandleOKCallback() {
     Local<Array> captures = Nan::New<Array>(resultCount);
     for (int index = 0; index < resultCount; index++) {
       int captureStart = source->ConvertUtf8OffsetToUtf16(bestResult->LocationAt(index));
-      int captureLength = source->ConvertUnicodeLengthToUtf16(captureStart, bestResult->LengthAt(index));
+      int captureEnd = source->ConvertUtf8OffsetToUtf16(bestResult->LocationAt(index) + bestResult->LengthAt(index));
 
       Local<Object> capture = Nan::New<Object>();
       capture->Set(Nan::New<String>("index").ToLocalChecked(), Nan::New<Number>(index));
       capture->Set(Nan::New<String>("start").ToLocalChecked(), Nan::New<Number>(captureStart));
-      capture->Set(Nan::New<String>("end").ToLocalChecked(), Nan::New<Number>(captureStart + captureLength));
-      capture->Set(Nan::New<String>("length").ToLocalChecked(), Nan::New<Number>(captureLength));
+      capture->Set(Nan::New<String>("end").ToLocalChecked(), Nan::New<Number>(captureEnd));
+      capture->Set(Nan::New<String>("length").ToLocalChecked(), Nan::New<Number>(captureEnd - captureStart));
       captures->Set(index, capture);
     }
     result->Set(Nan::New<String>("captureIndices").ToLocalChecked(), captures);

--- a/src/onig-scanner.cc
+++ b/src/onig-scanner.cc
@@ -102,13 +102,13 @@ Local<Value> OnigScanner::CaptureIndicesForMatch(OnigResult* result, OnigString*
 
   for (int index = 0; index < resultCount; index++) {
     int captureStart = source->ConvertUtf8OffsetToUtf16(result->LocationAt(index));
-    int captureLength = source->ConvertUnicodeLengthToUtf16(captureStart, result->LengthAt(index));
+    int captureEnd = source->ConvertUtf8OffsetToUtf16(result->LocationAt(index) + result->LengthAt(index));
 
     Local<Object> capture = Nan::New<Object>();
     capture->Set(Nan::New<String>("index").ToLocalChecked(), Nan::New<Number>(index));
     capture->Set(Nan::New<String>("start").ToLocalChecked(), Nan::New<Number>(captureStart));
-    capture->Set(Nan::New<String>("end").ToLocalChecked(), Nan::New<Number>(captureStart + captureLength));
-    capture->Set(Nan::New<String>("length").ToLocalChecked(), Nan::New<Number>(captureLength));
+    capture->Set(Nan::New<String>("end").ToLocalChecked(), Nan::New<Number>(captureEnd));
+    capture->Set(Nan::New<String>("length").ToLocalChecked(), Nan::New<Number>(captureEnd - captureStart));
     captures->Set(index, capture);
   }
 

--- a/src/onig-string.cc
+++ b/src/onig-string.cc
@@ -36,6 +36,7 @@ OnigString::OnigString(Local<String> value)
 
     // http://stackoverflow.com/a/148766
     unsigned int codepoint = 0;
+    int i16_codepoint_start = 0;
     int i8 = 0;
     for (int i16 = 0, len = utf16_length_; i16 < len; i16++) {
       uint16_t in = (*utf16Value)[i16];
@@ -52,31 +53,32 @@ OnigString::OnigString(Local<String> value)
         }
 
         if (codepoint <= 0x7f) {
-          utf8OffsetToUtf16[i8] = i16;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
         } else if (codepoint <= 0x7ff) {
-          utf8OffsetToUtf16[i8] = i16;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
-          utf8OffsetToUtf16[i8] = i16;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
         } else if (codepoint <= 0xffff) {
-          utf8OffsetToUtf16[i8] = i16 - 1;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
-          utf8OffsetToUtf16[i8] = i16 - 1;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
-          utf8OffsetToUtf16[i8] = i16 - 1;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
         } else {
-          utf8OffsetToUtf16[i8] = i16 - 1;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
-          utf8OffsetToUtf16[i8] = i16 - 1;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
-          utf8OffsetToUtf16[i8] = i16 - 1;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
-          utf8OffsetToUtf16[i8] = i16 - 1;
+          utf8OffsetToUtf16[i8] = i16_codepoint_start;
           i8++;
         }
         codepoint = 0;
+        i16_codepoint_start = i16 + 1;
       }
     }
   }

--- a/src/onig-string.h
+++ b/src/onig-string.h
@@ -20,21 +20,23 @@ class OnigString : public node::ObjectWrap {
   int uniqueId() { return uniqueId_; }
 
   const char* utf8_value() const { return *utf8Value; }
-  size_t utf8_length() const { return utf8Value.length(); }
+  size_t utf8_length() const { return utf8_length_; }
 
   int ConvertUtf8OffsetToUtf16(int utf8Offset);
   int ConvertUtf16OffsetToUtf8(int utf16Offset);
-  int ConvertUnicodeLengthToUtf16(int utf16Offset, int codePointLength);
 
  private:
   static NAN_METHOD(New);
 
   int uniqueId_;
   String::Utf8Value utf8Value;
+  size_t utf8_length_;
   bool hasMultiByteChars;
+
+  // - the following members are used only if hasMultiByteChars is true
+  size_t utf16_length_;
   int *utf16OffsetToUtf8;
   int *utf8OffsetToUtf16;
-  bool *utf16OffsetIsCodePointEnd;
 };
 
 #endif  // SRC_ONIG_STRING_H_


### PR DESCRIPTION
@zcbenz 

I am sorry my previous pull request #46 introduced a regression around utf8 <-> utf16 conversion, specifically I misunderstood `OnigResult.LengthAt` to be the count of code points instead of the byte count -- it being the byte count makes a lot more sense.

I have added a regression test and removed `OnigString.utf16OffsetIsCodePointEnd` which is no longer needed.

@EvilBeaver discovered the issue in VS Code (Microsoft/vscode#2170)