### PR TITLE
src: don't use deprecated v8::Template::Set()

### DIFF
--- a/src/onig-scanner.cc
+++ b/src/onig-scanner.cc
@@ -7,8 +7,8 @@ void OnigScanner::Init(Local<Object> target) {
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(OnigScanner::New);
   tpl->SetClassName(Nan::New<String>("OnigScanner").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  tpl->PrototypeTemplate()->Set(Nan::New<String>("_findNextMatch").ToLocalChecked(), Nan::New<FunctionTemplate>(OnigScanner::FindNextMatch)->GetFunction());
-  tpl->PrototypeTemplate()->Set(Nan::New<String>("_findNextMatchSync").ToLocalChecked(), Nan::New<FunctionTemplate>(OnigScanner::FindNextMatchSync)->GetFunction());
+  tpl->PrototypeTemplate()->Set(Nan::New<String>("_findNextMatch").ToLocalChecked(), Nan::New<FunctionTemplate>(OnigScanner::FindNextMatch));
+  tpl->PrototypeTemplate()->Set(Nan::New<String>("_findNextMatchSync").ToLocalChecked(), Nan::New<FunctionTemplate>(OnigScanner::FindNextMatchSync));
 
   target->Set(Nan::New<String>("OnigScanner").ToLocalChecked(), tpl->GetFunction());
 }


### PR DESCRIPTION
See [0] and [1]: starting with Node.js v6, setting non-primitive values
on FunctionTemplate and ObjectTemplate instances is discouraged; v7 will
downright disallow it. Update the code base.

[0] https://github.com/nodejs/node/issues/6216
[1] https://github.com/nodejs/node/pull/6228

and thanks to @bnoordhuis for the fix.