### PR TITLE
Fixes #56: Do not ignore unmatched high surrogates, check index is within bounds

### DIFF
--- a/src/onig-string.cc
+++ b/src/onig-string.cc
@@ -35,50 +35,46 @@ OnigString::OnigString(Local<String> value)
     utf8OffsetToUtf16[utf8_length_] = utf16_length_;
 
     // http://stackoverflow.com/a/148766
-    unsigned int codepoint = 0;
-    int i16_codepoint_start = 0;
     int i8 = 0;
     for (int i16 = 0, len = utf16_length_; i16 < len; i16++) {
       uint16_t in = (*utf16Value)[i16];
 
-      utf16OffsetToUtf8[i16] = i8;
+      unsigned int codepoint = in;
+      bool wasSurrogatePair = false;
 
       if (in >= 0xd800 && in <= 0xdbff) {
-        codepoint = ((in - 0xd800) << 10) + 0x10000;
-      } else {
-        if (in >= 0xdc00 && in <= 0xdfff) {
-          codepoint |= in - 0xdc00;
-        } else {
-          codepoint = in;
+        // Hit a high surrogate, try to look for a matching low surrogate
+        if (i16 + 1 < len) {
+          uint16_t next = (*utf16Value)[i16 + 1];
+          if (next >= 0xdc00 && next <= 0xdfff) {
+            // Found the matching low surrogate
+            codepoint = (((in - 0xd800) << 10) + 0x10000) | (next - 0xdc00);
+            wasSurrogatePair = true;
+          }
         }
+      }
 
-        if (codepoint <= 0x7f) {
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-        } else if (codepoint <= 0x7ff) {
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-        } else if (codepoint <= 0xffff) {
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-        } else {
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-          utf8OffsetToUtf16[i8] = i16_codepoint_start;
-          i8++;
-        }
-        codepoint = 0;
-        i16_codepoint_start = i16 + 1;
+      utf16OffsetToUtf8[i16] = i8;
+
+      if (codepoint <= 0x7f) {
+        utf8OffsetToUtf16[i8++] = i16;
+      } else if (codepoint <= 0x7ff) {
+        utf8OffsetToUtf16[i8++] = i16;
+        utf8OffsetToUtf16[i8++] = i16;
+      } else if (codepoint <= 0xffff) {
+        utf8OffsetToUtf16[i8++] = i16;
+        utf8OffsetToUtf16[i8++] = i16;
+        utf8OffsetToUtf16[i8++] = i16;
+      } else {
+        utf8OffsetToUtf16[i8++] = i16;
+        utf8OffsetToUtf16[i8++] = i16;
+        utf8OffsetToUtf16[i8++] = i16;
+        utf8OffsetToUtf16[i8++] = i16;
+      }
+
+      if (wasSurrogatePair) {
+        utf16OffsetToUtf8[i16 + 1] = utf16OffsetToUtf8[i16];
+        i16++;
       }
     }
   }
@@ -93,6 +89,12 @@ OnigString::~OnigString() {
 
 int OnigString::ConvertUtf8OffsetToUtf16(int utf8Offset) {
   if (hasMultiByteChars) {
+    if (utf8Offset < 0) {
+      return 0;
+    }
+    if ((size_t)utf8Offset > utf8_length_) {
+      return utf16_length_;
+    }
     return utf8OffsetToUtf16[utf8Offset];
   }
   return utf8Offset;
@@ -100,6 +102,12 @@ int OnigString::ConvertUtf8OffsetToUtf16(int utf8Offset) {
 
 int OnigString::ConvertUtf16OffsetToUtf8(int utf16Offset) {
   if (hasMultiByteChars) {
+    if (utf16Offset < 0) {
+      return 0;
+    }
+    if ((size_t)utf16Offset > utf16_length_) {
+      return utf8_length_;
+    }
     return utf16OffsetToUtf8[utf16Offset];
   }
   return utf16Offset;


### PR DESCRIPTION
This changes the way high surrogates are interpreted:
* before, they would be simply skipped if they would not be immediately followed by a low surrogate and the utf8->utf16 offset map would diverge from v8's conversion of utf16->utf8.
* now, high surrogates are interpreted as code points if they are not immediately followed by a low surrogate. From my debugging the utf8 value of strings, this aligns with v8's handling of this invalid case
* I also added bound checks in `ConvertUtf8OffsetToUtf16` and `ConvertUtf16OffsetToUtf8`