### PR TITLE
Use signed integer types to store string lengths

### DIFF
--- a/src/onig-string.cc
+++ b/src/onig-string.cc
@@ -92,7 +92,7 @@ int OnigString::ConvertUtf8OffsetToUtf16(int utf8Offset) {
     if (utf8Offset < 0) {
       return 0;
     }
-    if ((size_t)utf8Offset > utf8_length_) {
+    if (utf8Offset > utf8_length_) {
       return utf16_length_;
     }
     return utf8OffsetToUtf16[utf8Offset];
@@ -105,7 +105,7 @@ int OnigString::ConvertUtf16OffsetToUtf8(int utf16Offset) {
     if (utf16Offset < 0) {
       return 0;
     }
-    if ((size_t)utf16Offset > utf16_length_) {
+    if (utf16Offset > utf16_length_) {
       return utf8_length_;
     }
     return utf16OffsetToUtf8[utf16Offset];

--- a/src/onig-string.h
+++ b/src/onig-string.h
@@ -30,11 +30,11 @@ class OnigString : public node::ObjectWrap {
 
   int uniqueId_;
   String::Utf8Value utf8Value;
-  size_t utf8_length_;
+  int utf8_length_;
   bool hasMultiByteChars;
 
   // - the following members are used only if hasMultiByteChars is true
-  size_t utf16_length_;
+  int utf16_length_;
   int *utf16OffsetToUtf8;
   int *utf8OffsetToUtf16;
 };


### PR DESCRIPTION
Fixes #58 

Since `utf8_length_` and `utf16_length_` get their values from v8 `length()` methods, which return `int`, it makes little sense to use `size_t` internally.