### PR TITLE
Only minor syntactic sugar removed from ES6 to ES5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - g++-4.8
 
 node_js:
-  - "node"
+  - "4"
 
 install:
   - export CXX=g++-4.8

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs')
 const path = require('path')
-const {OnigScanner} = require('..')
+const OnigScanner = require('..').OnigScanner
 
 function runBenchmarkSync (lines, scanner) {
   let startTime = Date.now()

--- a/spec/onig-reg-exp-spec.js
+++ b/spec/onig-reg-exp-spec.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const OnigRegExp = require('..').OnigRegExp
 
 describe('OnigRegExp', () => {

--- a/spec/onig-reg-exp-spec.js
+++ b/spec/onig-reg-exp-spec.js
@@ -1,4 +1,4 @@
-const {OnigRegExp} = require('..')
+const OnigRegExp = require('..').OnigRegExp
 
 describe('OnigRegExp', () => {
   describe('::search(string, index, callback)', () => {

--- a/spec/onig-scanner-spec.js
+++ b/spec/onig-scanner-spec.js
@@ -1,4 +1,4 @@
-const {OnigScanner} = require('..')
+const OnigScanner = require('..').OnigScanner
 
 describe('OnigScanner', () => {
   describe('::findNextMatchSync', () => {

--- a/spec/onig-scanner-spec.js
+++ b/spec/onig-scanner-spec.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const OnigScanner = require('..').OnigScanner
 
 describe('OnigScanner', () => {

--- a/spec/onig-string-spec.js
+++ b/spec/onig-string-spec.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const OnigString = require('..').OnigString
 
 describe('OnigString', () => {

--- a/spec/onig-string-spec.js
+++ b/spec/onig-string-spec.js
@@ -1,4 +1,4 @@
-const {OnigString} = require('..')
+const OnigString = require('..').OnigString
 
 describe('OnigString', () => {
   it('has a length property', () => {

--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const OnigScanner = require('../build/Release/onig_scanner.node').OnigScanner
 const OnigString = require('../build/Release/onig_scanner.node').OnigString
 

--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -3,6 +3,7 @@
 const OnigScanner = require('../build/Release/onig_scanner.node').OnigScanner
 const OnigString = require('../build/Release/onig_scanner.node').OnigString
 
+/*
 class OnigRegExp {
   constructor (source) {
     this.source = source.toString()
@@ -48,6 +49,61 @@ class OnigRegExp {
     this.search(string, 0, (error, result) => callback(error, result != null))
   }
 }
+*/
+
+function OnigRegExp(source) {
+  this.source = source;
+  this.scanner = new OnigScanner([this.source]);
+}
+
+OnigRegExp.prototype.captureIndicesForMatch = function(string, match) {
+  var capture, captureIndices, i, len;
+  if (match != null) {
+    captureIndices = match.captureIndices;
+    string = this.scanner.convertToString(string);
+    for (i = 0, len = captureIndices.length; i < len; i++) {
+      capture = captureIndices[i];
+      capture.match = string.slice(capture.start, capture.end);
+    }
+    return captureIndices;
+  } else {
+    return null;
+  }
+};
+
+OnigRegExp.prototype.searchSync = function(string, startPosition) {
+  var match;
+  if (startPosition == null) {
+    startPosition = 0;
+  }
+  match = this.scanner.findNextMatchSync(string, startPosition);
+  return this.captureIndicesForMatch(string, match);
+};
+
+OnigRegExp.prototype.search = function(string, startPosition, callback) {
+  if (startPosition == null) {
+    startPosition = 0;
+  }
+  if (typeof startPosition === 'function') {
+    callback = startPosition;
+    startPosition = 0;
+  }
+  return this.scanner.findNextMatch(string, startPosition, (function(_this) {
+    return function(error, match) {
+      return typeof callback === "function" ? callback(error, _this.captureIndicesForMatch(string, match)) : void 0;
+    };
+  })(this));
+};
+
+OnigRegExp.prototype.testSync = function(string) {
+  return this.searchSync(string) != null;
+};
+
+OnigRegExp.prototype.test = function(string, callback) {
+  return this.search(string, 0, function(error, result) {
+    return typeof callback === "function" ? callback(error, result != null) : void 0;
+  });
+};
 
 OnigScanner.prototype.findNextMatch = function (string, startPosition, callback) {
   if (startPosition == null) startPosition = 0

--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -1,4 +1,5 @@
-const {OnigScanner, OnigString} = require('../build/Release/onig_scanner.node')
+const OnigScanner = require('../build/Release/onig_scanner.node').OnigScanner
+const OnigString = require('../build/Release/onig_scanner.node').OnigString
 
 class OnigRegExp {
   constructor (source) {

--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -3,54 +3,6 @@
 const OnigScanner = require('../build/Release/onig_scanner.node').OnigScanner
 const OnigString = require('../build/Release/onig_scanner.node').OnigString
 
-/*
-class OnigRegExp {
-  constructor (source) {
-    this.source = source.toString()
-    this.scanner = new OnigScanner([this.source])
-  }
-
-  captureIndicesForMatch (string, match) {
-    if (match) {
-      let {captureIndices} = match
-      string = this.scanner.convertToString(string)
-      for (let capture of Array.from(captureIndices)) {
-        capture.match = string.slice(capture.start, capture.end)
-      }
-      return captureIndices
-    } else {
-      return null
-    }
-  }
-
-  searchSync (string, startPosition) {
-    if (startPosition == null) startPosition = 0
-    let match = this.scanner.findNextMatchSync(string, startPosition)
-    return this.captureIndicesForMatch(string, match)
-  }
-
-  search (string, startPosition, callback) {
-    if (startPosition == null) { startPosition = 0 }
-    if (typeof startPosition === 'function') {
-      callback = startPosition
-      startPosition = 0
-    }
-
-    this.scanner.findNextMatch(string, startPosition, (error, match) => {
-      callback(error, this.captureIndicesForMatch(string, match))
-    })
-  }
-
-  testSync (string) {
-    return this.searchSync(string) != null
-  }
-
-  test (string, callback) {
-    this.search(string, 0, (error, result) => callback(error, result != null))
-  }
-}
-*/
-
 function OnigRegExp(source) {
   this.source = source;
   this.scanner = new OnigScanner([this.source]);


### PR DESCRIPTION
Fixes #65 

### Approach

1. One step, one commit. For easy review.
2. Start by setting the wanted Node support to work toward getting the Travis CI green arrow.
3. Only remove syntactic sugar to be ES5 compatible
4. Squash commits at merge if desired
