### PR TITLE
Fix 'npm test' on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "nan": "^2.0.9"
   },
   "scripts": {
-    "test": "jasmine-focused --captureExceptions spec/*",
+    "test": "jasmine-focused --captureExceptions spec/",
     "benchmark": "benchmark/benchmark.coffee"
   }
 }


### PR DESCRIPTION
Previously:
```
npm test
> oniguruma@7.0.0 test C:\projects\node-oniguruma
> jasmine-focused --captureExceptions spec/*
File: C:\projects\node-oniguruma\spec\* is missing.
```

With change:
```
npm test
> oniguruma@7.0.0 test E:\git\wmhilton-contrib\node-oniguruma
> jasmine-focused --captureExceptions spec/
..........................
Finished in 0.183 seconds
26 tests, 109 assertions, 0 failures, 0 skipped
```