### PR TITLE
Change the for statement of OnigRegExp.prototype.captureIndicesForMatch to map

### DIFF
--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -24,11 +24,10 @@ OnigRegExp.prototype.captureIndicesForMatch = function(string, match) {
 };
 
 OnigRegExp.prototype.searchSync = function(string, startPosition) {
-  var match;
   if (startPosition == null) {
     startPosition = 0;
   }
-  match = this.scanner.findNextMatchSync(string, startPosition);
+  const match = this.scanner.findNextMatchSync(string, startPosition);
   return this.captureIndicesForMatch(string, match);
 };
 

--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -9,18 +9,15 @@ function OnigRegExp(source) {
 }
 
 OnigRegExp.prototype.captureIndicesForMatch = function(string, match) {
-  var capture, captureIndices, i, len;
-  if (match != null) {
-    captureIndices = match.captureIndices;
-    string = this.scanner.convertToString(string);
-    for (i = 0, len = captureIndices.length; i < len; i++) {
-      capture = captureIndices[i];
-      capture.match = string.slice(capture.start, capture.end);
-    }
-    return captureIndices;
-  } else {
+  if (match == null) {
     return null;
   }
+
+  string = this.scanner.convertToString(string);
+  return match.captureIndices.map((capture) => {
+    capture.match = string.slice(capture.start, capture.end);
+    return capture
+  })
 };
 
 OnigRegExp.prototype.searchSync = function(string, startPosition) {


### PR DESCRIPTION
It is a point where we lost assignment in `var`, which is likely to cause side effects.

In addition I changed the null judgment. This made the indent shallow.