### PR TITLE
Fix deprecated warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -272,9 +272,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jasmine-focused": "~1.0.7"
   },
   "dependencies": {
-    "nan": "^2.10.0"
+    "nan": "^2.12.1"
   },
   "scripts": {
     "test": "jasmine-focused --captureExceptions spec/",

--- a/src/onig-scanner.cc
+++ b/src/onig-scanner.cc
@@ -39,7 +39,7 @@ NAN_METHOD(OnigScanner::FindNextMatchSync) {
     Local<String> v8String = Local<String>::Cast(info[0]);
     result = scanner->FindNextMatchSync(v8String, param2);
   } else {
-    OnigString* onigString = node::ObjectWrap::Unwrap<OnigString>(info[0]->ToObject());
+    OnigString* onigString = node::ObjectWrap::Unwrap<OnigString>(info[0].As<Object>());
     result = scanner->FindNextMatchSync(onigString, param2);
   }
 


### PR DESCRIPTION
- Upgrade `nan`
- Fix deprecated warning
```
% node -v
v11.6.0
```

The following warning.

```
../src/onig-scanner.cc: In static member function ‘static
Nan::NAN_METHOD_RETURN_TYPE
OnigScanner::FindNextMatchSync(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/onig-scanner.cc:42:85: warning: ‘v8::Local<v8::Object>
v8::Value::ToObject() const’ is deprecated: Use maybe version
[-Wdeprecated-declarations]
     OnigString* onigString =
     node::ObjectWrap::Unwrap<OnigString>(info[0]->ToObject());
```