### PR TITLE
Add endPosition parameter to findNextMatchSync.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ scanner.findNextMatch 'abc', (error, match) ->
   }
 ```
 
-### OnigScanner::findNextMatchSync(string, startPosition)
+### OnigScanner::findNextMatchSync(string, startPosition, endPosition)
 
 Synchronously find the next match from a given position.
 
 `string` - The string to search.
 
 `startPosition` - The optional position to start at, defaults to `0`.
+
+`endPosition` - The optional position to end at, defaults to the end of the string.
 
 Returns an object containing details about the match or `null` if no match.
 

--- a/spec/onig-scanner-spec.js
+++ b/spec/onig-scanner-spec.js
@@ -14,6 +14,16 @@ describe('OnigScanner', () => {
       expect(scanner.findNextMatchSync('xxaxxbxxc', 9)).toBe(null)
     })
 
+    it('supports explicit end indexes', () => {
+      let scanner = new OnigScanner(['a$', 'b$'])
+      expect(scanner.findNextMatchSync('xabc', 0, 1)).toBe(null)
+      expect(scanner.findNextMatchSync('xabc', 0, 2).index).toBe(0)
+      expect(scanner.findNextMatchSync('xabc', 0, 3).index).toBe(1)
+      expect(scanner.findNextMatchSync('xabc', 0, 4)).toBe(null)
+
+      expect(scanner.findNextMatchSync('xabc', 3, 2)).toBe(null)
+    })
+
     it('includes the scanner with the results', () => {
       let scanner = new OnigScanner(['a'])
       expect(scanner.findNextMatchSync('a', 0).scanner).toBe(scanner)

--- a/src/onig-reg-exp.cc
+++ b/src/onig-reg-exp.cc
@@ -38,11 +38,11 @@ OnigRegExp::~OnigRegExp() {
   if (regex_) onig_free(regex_);
 }
 
-shared_ptr<OnigResult> OnigRegExp::Search(OnigString* str, int position) {
+shared_ptr<OnigResult> OnigRegExp::Search(OnigString* str, int position, int endPosition) {
   if (hasGAnchor) {
     // Should not use caching, because the regular expression
     // targets the current search position (\G)
-    return Search(str->utf8_value(), position, str->utf8_length());
+    return Search(str->utf8_value(), position, endPosition);
   }
 
   if (lastSearchStrUniqueId == str->uniqueId() && lastSearchPosition <= position) {
@@ -53,7 +53,7 @@ shared_ptr<OnigResult> OnigRegExp::Search(OnigString* str, int position) {
 
   lastSearchStrUniqueId = str->uniqueId();
   lastSearchPosition = position;
-  lastSearchResult = Search(str->utf8_value(), position, str->utf8_length());
+  lastSearchResult = Search(str->utf8_value(), position, endPosition);
   return lastSearchResult;
 }
 

--- a/src/onig-reg-exp.h
+++ b/src/onig-reg-exp.h
@@ -15,7 +15,7 @@ class OnigRegExp {
   explicit OnigRegExp(const string& source);
   ~OnigRegExp();
 
-  shared_ptr<OnigResult> Search(OnigString* str, int position);
+  shared_ptr<OnigResult> Search(OnigString* str, int position, int endPosition);
 
  private:
   OnigRegExp(const OnigRegExp&);  // Disallow copying

--- a/src/onig-scanner-worker.cc
+++ b/src/onig-scanner-worker.cc
@@ -5,7 +5,7 @@ using ::v8::Number;
 using ::v8::Value;
 
 void OnigScannerWorker::Execute() {
-  bestResult = searcher->Search(source, charOffset);
+  bestResult = searcher->Search(source, charOffset, endCharOffset);
 }
 
 void OnigScannerWorker::HandleOKCallback() {

--- a/src/onig-scanner-worker.h
+++ b/src/onig-scanner-worker.h
@@ -18,7 +18,8 @@ class OnigScannerWorker : public Nan::AsyncWorker {
                     Local<String> v8String,
                     int charOffset)
     : Nan::AsyncWorker(callback),
-      charOffset(charOffset) {
+      charOffset(charOffset),
+      endCharOffset(-1) {
         source = new OnigString(v8String);
     searcher = shared_ptr<OnigSearcher>(new OnigSearcher(regExps));
   }
@@ -33,6 +34,7 @@ class OnigScannerWorker : public Nan::AsyncWorker {
  private:
   OnigString* source;
   int charOffset;
+  int endCharOffset;
   shared_ptr<OnigSearcher> searcher;
   shared_ptr<OnigResult> bestResult;
 };

--- a/src/onig-scanner.cc
+++ b/src/onig-scanner.cc
@@ -33,14 +33,15 @@ NAN_METHOD(OnigScanner::FindNextMatchSync) {
 
   Local<Object> param1 = Local<Object>::Cast(info[0]);
   Local<Number> param2 = Local<Number>::Cast(info[1]);
+  Local<Number> param3 = Local<Number>::Cast(info[2]);
   Local<Value> result;
 
   if (param1->IsString()) {
     Local<String> v8String = Local<String>::Cast(info[0]);
-    result = scanner->FindNextMatchSync(v8String, param2);
+    result = scanner->FindNextMatchSync(v8String, param2, param3);
   } else {
     OnigString* onigString = node::ObjectWrap::Unwrap<OnigString>(info[0]->ToObject());
-    result = scanner->FindNextMatchSync(onigString, param2);
+    result = scanner->FindNextMatchSync(onigString, param2, param3);
   }
 
   info.GetReturnValue().Set(result);
@@ -75,17 +76,18 @@ void OnigScanner::FindNextMatch(Local<String> v8String, Local<Number> v8StartLoc
   Nan::AsyncQueueWorker(worker);
 }
 
-Local<Value> OnigScanner::FindNextMatchSync(Local<String> v8String, Local<Number> v8StartLocation) {
+Local<Value> OnigScanner::FindNextMatchSync(Local<String> v8String, Local<Number> v8StartLocation, Local<Number> v8EndLocation) {
   OnigString* source = new OnigString(v8String);
-  Local<Value> r = FindNextMatchSync(source, v8StartLocation);
+  Local<Value> r = FindNextMatchSync(source, v8StartLocation, v8EndLocation);
   delete source;
   return r;
 }
 
-Local<Value> OnigScanner::FindNextMatchSync(OnigString* source, Local<Number> v8StartLocation) {
+Local<Value> OnigScanner::FindNextMatchSync(OnigString* source, Local<Number> v8StartLocation, Local<Number> v8EndLocation) {
   int charOffset = v8StartLocation->Value();
+  int charEndOffset = v8EndLocation->Value();
 
-  shared_ptr<OnigResult> bestResult = searcher->Search(source, charOffset);
+  shared_ptr<OnigResult> bestResult = searcher->Search(source, charOffset, charEndOffset);
   if (bestResult != NULL) {
     Local<Object> result = Nan::New<Object>();
     result->Set(Nan::New<String>("index").ToLocalChecked(), Nan::New<Number>(bestResult->Index()));

--- a/src/onig-scanner.h
+++ b/src/onig-scanner.h
@@ -30,8 +30,8 @@ class OnigScanner : public node::ObjectWrap {
   ~OnigScanner();
 
   void FindNextMatch(Local<String> v8String, Local<Number> v8StartLocation, Local<Function> v8Callback);
-  Local<Value> FindNextMatchSync(OnigString* onigString, Local<Number> v8StartLocation);
-  Local<Value> FindNextMatchSync(Local<String> v8String, Local<Number> v8StartLocation);
+  Local<Value> FindNextMatchSync(OnigString* onigString, Local<Number> v8StartLocation, Local<Number> v8EndLocation);
+  Local<Value> FindNextMatchSync(Local<String> v8String, Local<Number> v8StartLocation, Local<Number> v8EndLocation);
   static Local<Value> CaptureIndicesForMatch(OnigResult* result, OnigString* source);
 
   vector<shared_ptr<OnigRegExp>> regExps;

--- a/src/onig-searcher.cc
+++ b/src/onig-searcher.cc
@@ -1,7 +1,14 @@
 #include "onig-searcher.h"
 
-shared_ptr<OnigResult> OnigSearcher::Search(OnigString* source, int charOffset) {
+shared_ptr<OnigResult> OnigSearcher::Search(OnigString* source, int charOffset, int endCharOffset) {
   int byteOffset = source->ConvertUtf16OffsetToUtf8(charOffset);
+
+  int endByteOffset;
+  if (endCharOffset == -1) {
+    endByteOffset = source->utf8_length();
+  } else {
+    endByteOffset = source->ConvertUtf16OffsetToUtf8(endCharOffset);
+  }
 
   int bestLocation = 0;
   shared_ptr<OnigResult> bestResult;
@@ -10,7 +17,7 @@ shared_ptr<OnigResult> OnigSearcher::Search(OnigString* source, int charOffset) 
   int index = 0;
   while (iter < regExps.end()) {
     OnigRegExp *regExp = (*iter).get();
-    shared_ptr<OnigResult> result = regExp->Search(source, byteOffset);
+    shared_ptr<OnigResult> result = regExp->Search(source, byteOffset, endByteOffset);
     if (result != NULL && result->Count() > 0) {
       int location = result->LocationAt(0);
 

--- a/src/onig-searcher.h
+++ b/src/onig-searcher.h
@@ -16,7 +16,7 @@ class OnigSearcher {
 
   ~OnigSearcher() {}
 
-  shared_ptr<OnigResult> Search(OnigString* source, int charOffset);
+  shared_ptr<OnigResult> Search(OnigString* source, int charOffset, int endCharOffset);
 
  private:
   vector<shared_ptr<OnigRegExp>> regExps;

--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -73,12 +73,18 @@ OnigScanner.prototype.findNextMatch = function (string, startPosition, callback)
   })
 }
 
-OnigScanner.prototype.findNextMatchSync = function (string, startPosition) {
+OnigScanner.prototype.findNextMatchSync = function (string, startPosition, endPosition) {
   if (startPosition == null) { startPosition = 0 }
   string = this.convertToString(string)
   startPosition = this.convertToNumber(startPosition)
 
-  let match = this._findNextMatchSync(string, startPosition)
+  if (endPosition) {
+    endPosition = this.convertToNumber(endPosition);
+  } else {
+    endPosition = -1;
+  }
+
+  let match = this._findNextMatchSync(string, startPosition, endPosition)
   if (match) match.scanner = this
   return match
 }


### PR DESCRIPTION
For #79.

This is my first PR for the project, and I don't write much C, so this is probably overly conservative. Input would be appreciated.

- This PR only adds the parameter to `findNextMatchSync`, not to `findNextMatch`, `search`, or `searchSync`. Presumably we would want to add `endPosition` to all of the above.
- For clarity, it might be advisable to rename some of the `position` variables to `startPosition`.
- -1 is passed to the C code as a null value for `endPosition`. We could pass the (JS) string length instead, if that makes more sense.
- Docs and tests could be improved.