### PR TITLE
Safely cast params

### DIFF
--- a/src/onig-scanner.cc
+++ b/src/onig-scanner.cc
@@ -33,11 +33,10 @@ NAN_METHOD(OnigScanner::FindNextMatchSync) {
   Nan::HandleScope scope;
   OnigScanner* scanner = node::ObjectWrap::Unwrap<OnigScanner>(info.This());
 
-  Local<Object> param1 = Local<Object>::Cast(info[0]);
   Local<Number> param2 = Local<Number>::Cast(info[1]);
   Local<Value> result;
 
-  if (param1->IsString()) {
+  if (info[0]->IsString()) {
     Local<String> v8String = Local<String>::Cast(info[0]);
     result = scanner->FindNextMatchSync(v8String, param2);
   } else {

--- a/src/onig-string.cc
+++ b/src/onig-string.cc
@@ -12,12 +12,12 @@ void OnigString::Init(Local<Object> target) {
 }
 
 NAN_METHOD(OnigString::New) {
-  Local<String> content = Local<String>::Cast(info[0]);
-  if (!content->IsString()) {
+  if (!info[0]->IsString()) {
     Nan::ThrowTypeError("Argument must be a string");
     return;
   }
 
+  Local<String> content = Local<String>::Cast(info[0]);
   OnigString* string = new OnigString(content);
   string->Wrap(info.This());
   Nan::Set(info.This(), Nan::New("content").ToLocalChecked(), content);


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Tests raise fatal error when native code is built and run in debug mode.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Changes the value casts to be safer. The original `Local<Object>::Cast` is basically a no-op in release mode, but has an assertion in debug mode ([see this](https://stackoverflow.com/questions/15017113/cast-vs-toxxx-for-value-handles-in-v8)). Therefore, when it is running in debug mode and a non-object is passed, it errored. The change moves the cast after checking if it was a string, instead of casting and then checking what it was.


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
na

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
na

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
The tests pass (with both release and debug builds).

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

- Reorder JS to native variable type casts