### PR TITLE
Upgrade bindings to define transient types

### DIFF
--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -1,114 +1,132 @@
-'use strict'
+'use strict';
 
-const OnigScanner = require('../build/Release/onig_scanner.node').OnigScanner
-const OnigString = require('../build/Release/onig_scanner.node').OnigString
+const OnigScanner = require('../build/Release/onig_scanner.node').OnigScanner;
+const OnigString = require('../build/Release/onig_scanner.node').OnigString;
 
-function OnigRegExp(source) {
-  this.source = source;
-  this.scanner = new OnigScanner([this.source]);
+class OnigStringImpl extends OnigString {
+  substring(start, end) {
+    return this.content.substring(start, end);
+  }
+
+  toString(start, end) {
+    return this.content;
+  }
+
+  get length() {
+    return this.content.length;
+  }
 }
 
-OnigRegExp.prototype.captureIndicesForMatch = function(string, match) {
-  var capture, captureIndices, i, len;
-  if (match != null) {
-    captureIndices = match.captureIndices;
-    string = this.scanner.convertToString(string);
-    for (i = 0, len = captureIndices.length; i < len; i++) {
-      capture = captureIndices[i];
-      capture.match = string.slice(capture.start, capture.end);
+class OnigScannerImpl extends OnigScanner {
+  findNextMatch(string, startPosition, callback) {
+    if (startPosition == null) startPosition = 0;
+    if (typeof startPosition === 'function') {
+      callback = startPosition;
+      startPosition = 0;
     }
-    return captureIndices;
-  } else {
-    return null;
-  }
-};
 
-OnigRegExp.prototype.searchSync = function(string, startPosition) {
-  var match;
-  if (startPosition == null) {
-    startPosition = 0;
-  }
-  match = this.scanner.findNextMatchSync(string, startPosition);
-  return this.captureIndicesForMatch(string, match);
-};
+    string = this.convertToString(string);
+    startPosition = this.convertToNumber(startPosition);
 
-OnigRegExp.prototype.search = function(string, startPosition, callback) {
-  if (startPosition == null) {
-    startPosition = 0;
-  }
-  if (typeof startPosition === 'function') {
-    callback = startPosition;
-    startPosition = 0;
-  }
-  return this.scanner.findNextMatch(string, startPosition, (function(_this) {
-    return function(error, match) {
-      return typeof callback === "function" ? callback(error, _this.captureIndicesForMatch(string, match)) : void 0;
-    };
-  })(this));
-};
-
-OnigRegExp.prototype.testSync = function(string) {
-  return this.searchSync(string) != null;
-};
-
-OnigRegExp.prototype.test = function(string, callback) {
-  return this.search(string, 0, function(error, result) {
-    return typeof callback === "function" ? callback(error, result != null) : void 0;
-  });
-};
-
-OnigScanner.prototype.findNextMatch = function (string, startPosition, callback) {
-  if (startPosition == null) startPosition = 0
-  if (typeof startPosition === 'function') {
-    callback = startPosition
-    startPosition = 0
+    this._findNextMatch(string, startPosition, (error, match) => {
+      if (match) match.scanner = this;
+      return callback(error, match);
+    });
   }
 
-  string = this.convertToString(string)
-  startPosition = this.convertToNumber(startPosition)
+  findNextMatchSync(string, startPosition) {
+    if (startPosition == null) {
+      startPosition = 0;
+    }
+    string = this.convertToString(string);
+    startPosition = this.convertToNumber(startPosition);
 
-  this._findNextMatch(string, startPosition, (error, match) => {
-    if (match) match.scanner = this
-    return callback(error, match)
-  })
+    let match = this._findNextMatchSync(string, startPosition);
+    if (match) match.scanner = this;
+    return match;
+  }
+
+  convertToString(value) {
+    if (value === undefined) return 'undefined';
+    if (value === null) return 'null';
+    if (value instanceof OnigStringImpl) return value;
+    return value.toString();
+  }
+
+  convertToNumber(value) {
+    value = parseInt(value);
+    if (!isFinite(value)) {
+      value = 0;
+    }
+    value = Math.max(value, 0);
+    return value;
+  }
 }
 
-OnigScanner.prototype.findNextMatchSync = function (string, startPosition) {
-  if (startPosition == null) { startPosition = 0 }
-  string = this.convertToString(string)
-  startPosition = this.convertToNumber(startPosition)
+class OnigRegExpImpl {
+  constructor(source) {
+    this.source = source;
+    this.scanner = new OnigScannerImpl([this.source]);
+  }
 
-  let match = this._findNextMatchSync(string, startPosition)
-  if (match) match.scanner = this
-  return match
+  captureIndicesForMatch(string, match) {
+    var capture, captureIndices, i, len;
+    if (match != null) {
+      captureIndices = match.captureIndices;
+      string = this.scanner.convertToString(string);
+      for (i = 0, len = captureIndices.length; i < len; i++) {
+        capture = captureIndices[i];
+        capture.match = string.slice(capture.start, capture.end);
+      }
+      return captureIndices;
+    } else {
+      return null;
+    }
+  }
+
+  searchSync(string, startPosition) {
+    var match;
+    if (startPosition == null) {
+      startPosition = 0;
+    }
+    match = this.scanner.findNextMatchSync(string, startPosition);
+    return this.captureIndicesForMatch(string, match);
+  }
+
+  search(string, startPosition, callback) {
+    if (startPosition == null) {
+      startPosition = 0;
+    }
+    if (typeof startPosition === 'function') {
+      callback = startPosition;
+      startPosition = 0;
+    }
+    return this.scanner.findNextMatch(
+      string,
+      startPosition,
+      (function (_this) {
+        return function (error, match) {
+          return typeof callback === 'function'
+            ? callback(error, _this.captureIndicesForMatch(string, match))
+            : void 0;
+        };
+      })(this)
+    );
+  }
+
+  testSync(string) {
+    return this.searchSync(string) != null;
+  }
+
+  test(string, callback) {
+    return this.search(string, 0, function (error, result) {
+      return typeof callback === 'function'
+        ? callback(error, result != null)
+        : void 0;
+    });
+  }
 }
 
-OnigScanner.prototype.convertToString = function (value) {
-  if (value === undefined) return 'undefined'
-  if (value === null) return 'null'
-  if (value.constructor == OnigString) return value
-  return value.toString()
-}
-
-OnigScanner.prototype.convertToNumber = function (value) {
-  value = parseInt(value)
-  if (!isFinite(value)) { value = 0 }
-  value = Math.max(value, 0)
-  return value
-}
-
-OnigString.prototype.substring = function (start, end) {
-  return this.content.substring(start, end)
-}
-
-OnigString.prototype.toString = function (start, end) {
-  return this.content
-}
-
-Object.defineProperty(OnigString.prototype, 'length', {
-  get() { return this.content.length }
-})
-
-exports.OnigScanner = OnigScanner
-exports.OnigRegExp = OnigRegExp
-exports.OnigString = OnigString
+exports.OnigString = OnigStringImpl;
+exports.OnigScanner = OnigScannerImpl;
+exports.OnigRegExp = OnigRegExpImpl;


### PR DESCRIPTION

### Identify the Bug

When trying to write [jest](https://www.npmjs.com/package/jest) tests for a library built on top of oniguruma, tests often failed with the error:

```
TypeError: Cannot redefine property: length
```

Which I tracked to this line:

https://github.com/atom/node-oniguruma/blob/aa7f727aabc7c82a8c357c71c180557244b5566f/src/oniguruma.js#L108

This line adds some additional functionality to the native library imported, before exporting the result. It does so by directly modifying the prototype chain of the native types. If this module is evaluated once, that behavior is safe. But in case where the module cache is updated/modified as the tests are running, reevaluating that module will fail the process.

### Description of the Change

To fix this, and enable using this library safely when writing tests, I propose updating the binding to export child types with the augmented functionality. Not only it is more readable, it guards against such failures, by exporting a new type every time.

### Possible Drawbacks

First time contibutor, so I'd welcome guidance here.

### Verification Process

```
npm test
```

### Release Notes

N/A - a refactor with no user-facing changes.