### PR TITLE
Use C++17

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -99,13 +99,13 @@
       'conditions': [
         ['OS=="mac"', {
           'xcode_settings': {
-            'OTHER_CPLUSPLUSFLAGS': ['-std=c++11', '-stdlib=libc++'],
+            'OTHER_CPLUSPLUSFLAGS': ['-std=c++17', '-stdlib=libc++'],
             'MACOSX_DEPLOYMENT_TARGET': '10.7.0',
           }
         }],
         ['OS in "linux solaris"', {
           'cflags': [
-            '-std=c++0x',
+            '-std=c++17',
             '-Wno-unused-result',
             '-Wno-missing-field-initializers',
           ],
@@ -131,7 +131,7 @@
         }],
         ['OS=="freebsd"', {
           'cflags': [
-            '-std=c++0x',
+            '-std=c++17',
           ]
         }]
       ]


### PR DESCRIPTION
When building on electron 11.4.7 it fails with
error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
