### PR TITLE
Fix issue where oniguruma causes Jest tests to fail

### DIFF
--- a/src/oniguruma.js
+++ b/src/oniguruma.js
@@ -106,7 +106,8 @@ OnigString.prototype.toString = function (start, end) {
 }
 
 Object.defineProperty(OnigString.prototype, 'length', {
-  get() { return this.content.length }
+  get() { return this.content.length },
+  configurable: true
 })
 
 exports.OnigScanner = OnigScanner


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

### Identify the Bug

This fixes the same issue described in https://github.com/atom/node-oniguruma/pull/111 and in https://github.com/facebook/jest/issues/3552, that `oniguruma` will not work in jest when multiple tests use it.

### Description of the Change

By marking `length` as `configurable`, we prevent an error from being thrown if the code is run a second time (as it will be in a jest context).


### Possible Drawbacks

As far as I know, this should be harmless enough.

### Verification Process

Tried out the change locally.

### Release Notes

- Fixed an issue where a reimport of the library would fail in Node.js
