### PR TITLE
Remove windows-build-tools installation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14'
-    - name: Install windows-build-tools
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: |
-        npm config set msvs_version 2019
     - name: Install dependencies
       run: npm i
     - name: Run tests


### PR DESCRIPTION
I'm not sure why the github ci isn't triggering for prs anymore